### PR TITLE
Migrate to Auth::ManagedAuthenticator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*~
+/auto_generated/*

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,0 +1,5 @@
+en:
+  js:
+    login:
+      musicbrainz:
+        name: 'MusicBrainz'

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -8,3 +8,4 @@ en:
     oauth2_user_json_url: 'URL to fetch user JSON for MusicBrainz'
     oauth2_email_verified: 'Check this if MusicBrainz has verified the email address'
     oauth2_send_auth_header: 'Send the token as an HTTP Authorization header'
+    oauth2_button_title: 'Label for the login button'

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6,8 +6,5 @@ en:
     oauth2_authorize_url: 'Authorization URL for MusicBrainz'
     oauth2_token_url: 'Token URL for MusicBrainz'
     oauth2_user_json_url: 'URL to fetch user JSON for MusicBrainz'
-    oauth2_json_user_id_path: 'Path in the User JSON to the user id.'
-    oauth2_json_username_path: 'Path in the User JSON to the username.'
-    oauth2_json_email_path: 'Path in the User JSON to the email address.'
     oauth2_email_verified: 'Check this if MusicBrainz has verified the email address'
     oauth2_send_auth_header: 'Send the token as an HTTP Authorization header'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,9 +7,6 @@ login:
   oauth2_authorize_url: 'https://musicbrainz.org/oauth2/authorize'
   oauth2_token_url: 'https://musicbrainz.org/oauth2/token'
   oauth2_user_json_url: 'https://musicbrainz.org/oauth2/userinfo'
-  oauth2_json_user_id_path: 'sub'
-  oauth2_json_username_path: 'sub'
-  oauth2_json_email_path: 'email'
   oauth2_email_verified: true
   oauth2_send_auth_header: true
   oauth2_button_title:

--- a/lib/omniauth/strategies/omniauth-musicbrainz.rb
+++ b/lib/omniauth/strategies/omniauth-musicbrainz.rb
@@ -1,0 +1,59 @@
+require 'omniauth-oauth2'
+
+module OmniAuth
+  module Strategies
+    class Musicbrainz < ::OmniAuth::Strategies::OAuth2
+      # Give your strategy a name.
+      option :name, :musicbrainz
+
+      option :scope, "profile email"
+
+      # This is where you pass the options you would pass when
+      # initializing your consumer from the OAuth gem.
+      option :client_options, {
+        :site          => 'https://musicbrainz.org',
+        :authorize_url => '/oauth2/authorize',
+        :token_url     => '/oauth2/token'
+      }
+
+      option :provider_ignores_state, true
+
+      option :user_info_url, '/oauth2/userinfo'
+
+      # These are called after authentication has succeeded. If
+      # possible, you should try to set the UID without making
+      # additional calls (if the user id is returned with the token
+      # or as a URI parameter). This may not be possible with all
+      # providers.
+      uid{ raw_info['sub'] }
+
+      info do
+        {
+          :name => raw_info['sub'],
+          :email => raw_info['email'],
+          :email_verified => raw_info['email_verified'],
+        }
+      end
+
+      extra do
+        {
+          'raw_info' => raw_info
+        }
+      end
+
+      def raw_info
+        opts = {
+          :headers => {
+            'Authorization' => "Bearer #{access_token.token}"
+          }
+        }
+        @raw_info ||= access_token.get(options.user_info_url, opts).parsed
+      end
+
+      def callback_url
+        # Workaround for https://github.com/omniauth/omniauth-oauth2/issues/93
+        full_host + script_name + callback_path
+      end
+    end
+  end
+end

--- a/lib/omniauth/strategies/omniauth-musicbrainz.rb
+++ b/lib/omniauth/strategies/omniauth-musicbrainz.rb
@@ -29,6 +29,7 @@ module OmniAuth
 
       info do
         {
+          :nickname => raw_info['sub'],
           :name => raw_info['sub'],
           :email => raw_info['email'],
           :email_verified => raw_info['email_verified'],

--- a/plugin.rb
+++ b/plugin.rb
@@ -16,6 +16,11 @@ class Auth::MusicBrainzAuthenticator < Auth::ManagedAuthenticator
     SiteSetting.oauth2_enabled
   end
 
+  def match_by_username
+    # MusicBrainz user names are immutable
+    true
+  end
+
   def register_middleware(omniauth)
     omniauth.provider :musicbrainz,
                       setup: lambda {|env|

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,28 +1,35 @@
 # name: discourse-musicbrainz-auth
 # about: OAuth2 Plugin for MusicBrainz strategy
-# authors: Ohm Patel
+# version: 0.2
+# authors: Ohm Patel, Philipp Wolfer
+# url: https://github.com/metabrainz/discourse-musicbrainz-auth
 
-require_dependency 'auth/oauth2_authenticator.rb'
+require_relative 'lib/omniauth/strategies/omniauth-musicbrainz.rb'
 
-enabled_site_setting :oauth2_enabled
 
-class OAuth2BasicAuthenticator < ::Auth::OAuth2Authenticator
+class Auth::MusicBrainzAuthenticator < Auth::ManagedAuthenticator
+  def name
+    "musicbrainz"
+  end
+
+  def enabled?
+    SiteSetting.oauth2_enabled
+  end
+
   def register_middleware(omniauth)
-    omniauth.provider :oauth2,
-                      name: 'oauth2_basic',
+    omniauth.provider :musicbrainz,
                       setup: lambda {|env|
                         opts = env['omniauth.strategy'].options
                         opts[:client_id] = SiteSetting.oauth2_client_id
                         opts[:client_secret] = SiteSetting.oauth2_client_secret
-                        opts[:provider_ignores_state] = true
                         opts[:client_options] = {
                           authorize_url: SiteSetting.oauth2_authorize_url,
                           token_url: SiteSetting.oauth2_token_url
                         }
+                        opts[:user_info_url] = SiteSetting.oauth2_user_json_url
                         if SiteSetting.oauth2_send_auth_header?
                           opts[:token_params] = {headers: {'Authorization' => basic_auth_header }}
                         end
-                        opts[:scope] = "profile email"
                       }
   end
 
@@ -30,72 +37,20 @@ class OAuth2BasicAuthenticator < ::Auth::OAuth2Authenticator
     "Basic " + Base64.strict_encode64("#{SiteSetting.oauth2_client_id}:#{SiteSetting.oauth2_client_secret}")
   end
 
-  def walk_path(fragment, segments)
-    first_seg = segments[0]
-    return if first_seg.blank? || fragment.blank?
-    return nil unless fragment.is_a?(Hash)
-    deref = fragment[first_seg] || fragment[first_seg.to_sym]
-
-    return (deref.blank? || segments.size == 1) ? deref : walk_path(deref, segments[1..-1])
-  end
-
-  def json_walk(result, user_json, prop)
-    path = SiteSetting.send("oauth2_json_#{prop}_path")
-    if path.present?
-      segments = path.split('.')
-      val = walk_path(user_json, segments)
-      result[prop] = val if val.present?
-    end
-  end
-
-  def fetch_user_details(token)
-    user_json_url = SiteSetting.oauth2_user_json_url.sub(':token', token)
-    user_json = JSON.parse(open(user_json_url, 'Authorization' => "Bearer #{token}" ).read)
-
-    result = {}
-    if user_json.present?
-      json_walk(result, user_json, :user_id)
-      json_walk(result, user_json, :username)
-      json_walk(result, user_json, :email)
-    end
-
-    result
-  end
-
-  def after_authenticate(auth)
-    result = Auth::Result.new
-    token = auth['credentials']['token']
-    user_details = fetch_user_details(token)
-
-    result.username = user_details[:username]
-    result.email = user_details[:email]
-    result.email_valid = result.email.present? && SiteSetting.oauth2_email_verified?
-
-    current_info = ::PluginStore.get("oauth2_basic", "oauth2_basic_user_#{user_details[:user_id]}")
-    if current_info
-      result.user = User.where(id: current_info[:user_id]).first
-    elsif SiteSetting.oauth2_email_verified?
-      result.user = User.where(email: Email.downcase(result.email)).first
-    end
-
-    result.extra_data = { oauth2_basic_user_id: user_details[:user_id] }
-    result
-  end
-
-  def after_create_account(user, auth)
-    ::PluginStore.set("oauth2_basic", "oauth2_basic_user_#{auth[:extra_data][:oauth2_basic_user_id]}", {user_id: user.id })
+  def primary_email_verified?(auth_token)
+    SiteSetting.oauth2_email_verified? &&
+      !auth_token.dig(:info, :email).nil? &&
+      auth_token.dig(:info, :email_verified)
   end
 end
 
 auth_provider title_setting: "oauth2_button_title",
-              enabled_setting: "oauth2_enabled",
-              authenticator: OAuth2BasicAuthenticator.new('oauth2_basic'),
-              message: "OAuth2"
+              authenticator: Auth::MusicBrainzAuthenticator.new
 
 register_css <<CSS
 
-  button.btn-social.oauth2_basic {
-    background-color: #8A2BE2;
+  button.btn-social.musicbrainz {
+    background-color: #8A2BE2 !important;
   }
 
 CSS


### PR DESCRIPTION
Migrate to the new Discourse `Auth::ManagedAuthenticator`

See https://meta.discourse.org/t/adding-a-new-managed-authentication-method-to-discourse/106695 for details